### PR TITLE
Parameterize the "use_mount" setting in "datadog.conf"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 datadog_api_key: "youshouldsetthis"
-
+datadog_use_mount: "no"

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -1,4 +1,4 @@
 [Main]
 dd_url: https://app.datadoghq.com
 api_key: {{ datadog_api_key }}
-use_mount: no
+use_mount: {{ datadog_use_mount }}


### PR DESCRIPTION
The "use_mount" setting in "datadog.conf" was hard coded to "no". This change parameterizes the setting into an Ansible variable, maintaining the current setting of "no" as the default behavior.
