### PR TITLE
Generate Datadog agent check config files in "/etc/dd-agent/conf.d" via Ansible variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Ubuntu
 Role Variables
 --------------
 
-- `datadog_api_key` - your datadog API key
+- `datadog_api_key` - Your datadog API key
+- `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
 - `datadog_process_checks` - Array of process checks and options
+- `datadog_use_mount` - Use mount points instead of volumes to track disk and fs metrics
 
 Dependencies
 ------------
@@ -38,6 +40,26 @@ Example Playbooks
         cpu_check_interval: '0.2'
         exact_match: true
         ignore_denied_access: true
+    datadog_checks:
+      ssh_check:
+        init_config:
+        instances:
+          - host: localhost
+            port: 22
+            username: root
+            password: changeme
+            sftp_check: True
+            private_key_file:
+            add_missing_keys: True
+      nginx:
+        init_config:
+        instances:
+          - nginx_status_url: http://example.com/nginx_status/
+            tags:
+              - instance:foo
+          - nginx_status_url: http://example2.com:1234/nginx_status/
+            tags:
+              - instance:bar
 ```
 
 ```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
+---
 - include: debian.yml
   when: ansible_os_family == "Debian"
+
 - include: redhat.yml
   when: ansible_os_family == "RedHat"
+
+- name: Create a configuration file for each Datadog check
+  template:
+    src=checks.yaml.j2
+    dest=/etc/dd-agent/conf.d/{{ item }}.yaml
+  with_items: datadog_checks.keys()
+  notify:
+   - restart datadog

--- a/templates/checks.yaml.j2
+++ b/templates/checks.yaml.j2
@@ -1,0 +1,1 @@
+{{ datadog_checks[item] | to_nice_yaml }}


### PR DESCRIPTION
Many of the Datadog integrations listed on https://app.datadoghq.com/account/settings require special YAML config files to be dropped into "/etc/dd-agent/conf.d". I would love to be able to drop those YAML config files in programmatically, via Ansible. This change adds that functionality.

This follows the convention that the following role uses: https://github.com/jdauphant/ansible-role-nginx 
