### PR TITLE
Parameterize "/etc/dd-agent/datadog.conf" via Ansible variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Datadog Role
 ========
 
-Install and configure datadog agent.
+Install and configure Datadog agent.
 
 Currently only supports:
 Base agent
@@ -16,9 +16,9 @@ Role Variables
 --------------
 
 - `datadog_api_key` - Your datadog API key
+- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf`.
 - `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
 - `datadog_process_checks` - Array of process checks and options
-- `datadog_use_mount` - Use mount points instead of volumes to track disk and fs metrics
 
 Dependencies
 ------------
@@ -32,6 +32,11 @@ Example Playbooks
     - dustinbrown.datadog
   vars:
     datadog_api_key: "123456"
+    datadog_config:
+      api_key: "{{ datadog_api_key }}"
+      dd_url: "{{ datadog_url }}"
+      use_mount: "{{ datadog_use_mount }}"
+      tags: "mytag0, mytag1"
     datadog_process_checks:
       - name: ssh
         search_string: ['ssh', 'sshd' ]

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Ubuntu
 Role Variables
 --------------
 
-- `datadog_api_key` - Your datadog API key
-- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf`.
+- `datadog_api_key` - Your Datadog API key.
 - `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
-- `datadog_process_checks` - Array of process checks and options
+- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf`.
+- `datadog_process_checks` - Array of process checks and options.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,10 @@ datadog_api_key: "youshouldsetthis"
 datadog_url: "https://app.datadoghq.com"
 datadog_use_mount: "no"
 
+datadog_checks:
+
 datadog_config:
   api_key: "{{ datadog_api_key }}"
   dd_url: "{{ datadog_url }}"
   use_mount: "{{ datadog_use_mount }}"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 datadog_api_key: "youshouldsetthis"
+datadog_url: "https://app.datadoghq.com"
 datadog_use_mount: "no"
+
+datadog_config:
+  api_key: {{ datadog_api_key }}
+  dd_url: {{ datadog_url }}
+  use_mount: {{ datadog_use_mount }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ datadog_api_key: "youshouldsetthis"
 datadog_url: "https://app.datadoghq.com"
 datadog_use_mount: "no"
 
-datadog_checks:
+datadog_checks: {}
 
 datadog_config:
   api_key: "{{ datadog_api_key }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@ datadog_url: "https://app.datadoghq.com"
 datadog_use_mount: "no"
 
 datadog_config:
-  api_key: {{ datadog_api_key }}
-  dd_url: {{ datadog_url }}
-  use_mount: {{ datadog_use_mount }}
+  api_key: "{{ datadog_api_key }}"
+  dd_url: "{{ datadog_url }}"
+  use_mount: "{{ datadog_use_mount }}"

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -1,4 +1,5 @@
+# Managed by Ansible
+
 [Main]
-dd_url: https://app.datadoghq.com
-api_key: {{ datadog_api_key }}
-use_mount: {{ datadog_use_mount }}
+
+{{ datadog_config | to_nice_yaml }}


### PR DESCRIPTION
The current Ansible template for "/etc/dd-agent/datadog.conf" only specifies a few variables (Datadog URL, API key, use_mount), where there many, many potential settings available. See the full list at:
    https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example

This change introduces a new role variable, "datadog_config", whose key/value pairs will be placed in "/etc/dd-agent/datadog.conf". This allows users of the role to specify any sorts of settings they desire without modification of the role itself, like "tags", "listen_port", "device_blacklist_re", etc.

**NOTE:** In order to maintain backwards compatibility for existing users of this role, this is somewhat a convoluted implementation. Ideally "datadog_api_key" would not live as a first-order variable in the role.
