### PR TITLE
Only create /etc/dd-agent/conf.d/process.yaml when "datadog_process_checks" is defined

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,7 +9,7 @@
   notify: restart datadog
 
 - template: src=process.yaml.j2 dest=/etc/dd-agent/conf.d/process.yaml
+  when: datadog_process_checks is defined
   notify: restart datadog
 
 - service: name=datadog-agent state=started
-

--- a/templates/process.yaml.j2
+++ b/templates/process.yaml.j2
@@ -1,7 +1,6 @@
 init_config:
 
 instances:
-{% if datadog_process_checks is defined %}
 {% for process in datadog_process_checks %}
 - name: {{ process.name }}
   search_string: {{ process.search_string }}
@@ -16,4 +15,3 @@ instances:
   {% endif %}
 
 {% endfor %}
-{% endif %}


### PR DESCRIPTION
With the current implementation, if "datadog_process_checks" is not defined then an invalid file is placed in "/etc/dd-agent/conf.d/process.yaml". This results in a yellow alert in the Datadog GUI, as well as the following error in the CLI:

```
  Checks
  ======

    process
    -------
      - initialize check class [ERROR]: 'You need to have at least one instance defined in the YAML file for this check'
```

This change fixed the issue by moving the check for "datadog_process_checks" being defined to the task which processes the template.
