### PR TITLE
Adding enabled flag for Packer builds, preprod envs, etc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+datadog_enabled: yes
 datadog_api_key: "youshouldsetthis"
 datadog_url: "https://app.datadoghq.com"
 datadog_use_mount: "no"
@@ -9,4 +10,3 @@ datadog_config:
   api_key: "{{ datadog_api_key }}"
   dd_url: "{{ datadog_url }}"
   use_mount: "{{ datadog_use_mount }}"
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,4 @@
 
 - name: restart datadog
   action: service name=datadog-agent state=restarted
-
+  when: datadog_enabled

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,4 +12,8 @@
   when: datadog_process_checks is defined
   notify: restart datadog
 
-- service: name=datadog-agent state=started
+- service: name=datadog-agent state=started enabled=yes
+  when: datadog_enabled
+
+- service: name=datadog-agent state=stopped enabled=no
+  when: not datadog_enabled

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -8,5 +8,8 @@
 - template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog
 
-- service: name=datadog-agent state=started
+- service: name=datadog-agent state=started enabled=yes
+  when: datadog_enabled
 
+- service: name=datadog-agent state=stopped enabled=no
+  when: not datadog_enabled


### PR DESCRIPTION
Adds an enabled flag that will allow someone to install the datadog agent, but not enable it. The use case here is that we need the ability to burn the agent into an AMI and then judiciously enable the service at deploy time: We only use datadog for production environments, and don't want our volatile preprod getting tracked.

This change should be 100% backwards compatible with prior integrations. Also refrained from using the `ternary` Jinja filter so 1.8 support can be kept. Makes the role a little more verbose, but I figured that's ok.
